### PR TITLE
Avoid reloading output ZGroup

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MEDYANSimRunner"
 uuid = "b58a3b99-22e3-44d1-b5ea-258f082a6fe8"
 authors = ["nhz2 <nhz2@cornell.edu>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
@@ -29,5 +29,5 @@ LoggingExtras = "1"
 OrderedCollections = "1"
 Random = "1"
 SHA = "0.7, 1"
-SmallZarrGroups = "0.7.1, 0.8"
+SmallZarrGroups = "0.8.3"
 julia = "1.9"

--- a/src/run-sim.jl
+++ b/src/run-sim.jl
@@ -337,8 +337,11 @@ function zip_group(g::ZGroup)::Vector{UInt8}
     take!(io)
 end
 
+# ignores the top level "out" group
 function unzip_group(data::Vector{UInt8})::ZGroup
-    SmallZarrGroups.load_zip(data)
+    SmallZarrGroups.load_zip(data;
+        predicate=!startswith("out/"),
+    )
 end
 
 


### PR DESCRIPTION
There is no need to read back in the output when running or restarting the simulation.