### PR TITLE
Update to Julia 1.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
       matrix:
         version:
           - '1.11'
+          - 'pre'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -30,7 +31,7 @@ jobs:
         arch:
           - 'default'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}

--- a/Project.toml
+++ b/Project.toml
@@ -31,3 +31,6 @@ Random = "1"
 SHA = "0.7, 1"
 SmallZarrGroups = "0.8.3"
 julia = "1.11"
+
+[workspace]
+projects = ["test"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Pkg.add("MEDYANSimRunner")
 
 ## Warning: MEDYANSimRunner may be incompatible with a future release of Julia.
 
-Specifically `MEDYANSimRunner` uses `ccall` `:jl_fs_rename` and expects `copy(Random.default_rng())` to be `Xoshiro`. These are Julia internals.
+Specifically `MEDYANSimRunner` expects `copy(Random.default_rng())` to be `Xoshiro`. This is a Julia internal.
 
 ## Example
 Run the following in the root of this repo.

--- a/src/file-saving.jl
+++ b/src/file-saving.jl
@@ -78,21 +78,40 @@ function write_traj_file(
             error("short write of $(repr(file_name)) data")
         end
         close(temp_out)
-        # mv(temp_path, file_path; force=true)
-        err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), temp_path, file_path)
-        # on error, check if file was made by another process, and is still valid.
-        if err < 0
-            if isfile(file_path)
-                if filesize(file_path) == length(data)
-                    existing_hash = open(sha256, file_path)
-                    if new_hash == existing_hash
-                        # file exists and is correct, return
-                        return
+        # TODO Drop support for 1.11
+        @static if VERSION > v"1.12.0-rc"
+            try
+                Base.rename(temp_path, file_path)
+            catch err
+                err isa Base.IOError || rethrow()
+                # on error, check if file was made by another process, and is still valid.
+                if isfile(file_path)
+                    if filesize(file_path) == length(data)
+                        existing_hash = open(sha256, file_path)
+                        if new_hash == existing_hash
+                            # file exists and is correct, return
+                            return
+                        end
                     end
                 end
+                rethrow()
             end
-            # otherwise error
-            error("$(repr(file_path)) is corrupted")
+        else
+            err = ccall(:jl_fs_rename, Int32, (Cstring, Cstring), temp_path, file_path)
+            # on error, check if file was made by another process, and is still valid.
+            if err < 0
+                if isfile(file_path)
+                    if filesize(file_path) == length(data)
+                        existing_hash = open(sha256, file_path)
+                        if new_hash == existing_hash
+                            # file exists and is correct, return
+                            return
+                        end
+                    end
+                end
+                # otherwise error
+                error("$(repr(file_path)) is corrupted")
+            end
         end
         nothing
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,3 @@
-[sources]
-MEDYANSimRunner = {path = ".."}
-
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/test/example/output-ref-1_11/a/traj/footer.json
+++ b/test/example/output-ref-1_11/a/traj/footer.json
@@ -1,4 +1,4 @@
 {
     "steps": 3001,
-    "prev_sha256": "8f8fd9ea5814bb1a9a62b5d8203f640616c8b99762acead0a4e8fec17c309e70"
+    "prev_sha256": "dd937be825f22f9fbc6e49fd81bf5058ea7ccb8fdcf98adc7ae2143e6d7088d2"
 }

--- a/test/test_file-saving.jl
+++ b/test/test_file-saving.jl
@@ -31,7 +31,7 @@ using MEDYANSimRunner
     # write file with existing dir
     mktempdir() do path
         mkdir(joinpath(path, "snap1.txt"))
-        @test_throws ErrorException MEDYANSimRunner.write_traj_file(path, "snap1.txt", [0x01, 0x02])
+        @test_throws Exception MEDYANSimRunner.write_traj_file(path, "snap1.txt", [0x01, 0x02])
         @test isdir(joinpath(path, "snap1.txt"))
         @test readdir(path) == ["snap1.txt"]
     end


### PR DESCRIPTION
Julia 1.12 adds the `Base.rename` function, so the use of `ccall(:jl_fs_rename` can be removed.