### PR TITLE
Allow batch to be a range

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ with the `test/` environment and store the output in `test/output/`.
 
 The output directory will be created if it doesn't already exist.
 
-If the `"--batch=<job index>"` option is not included, all jobs specified in `main.jl` will be run.
+If the `"--batch=<job index or range>"` option is not included, all jobs specified in `main.jl` will be run.
+`<job index or range>` can be a `:` delimited range for example `1:3:end` to run every third job.
 
 
 ### `main.jl` script

--- a/src/cli-parsing.jl
+++ b/src/cli-parsing.jl
@@ -81,7 +81,7 @@ function parse_cli_args(cli_args, jobs::Vector{String})::Union{CLIOptions, Nothi
     else
         return batch_error()
     end::StepRange{Int, Int}
-    if !issubset(batch_range, 1:length(jobs)) 
+    if !issubset(batch_range, 1:length(jobs))
         @error "--batch must be a subset of $(1:length(jobs)), instead got $(batch_range)"
         return
     end

--- a/src/cli-parsing.jl
+++ b/src/cli-parsing.jl
@@ -1,6 +1,6 @@
 @kwdef struct CLIOptions
     continue_sim::Bool
-    batch::Int
+    batch_range::StepRange{Int, Int}
     out_dir::String
 end
 
@@ -16,8 +16,8 @@ const CLI_HELP = (
                             This directory will be created if it does not exist.
                             Defaults to the current working directory.
 
-        --batch=<job index> Run just one of the jobs.
-                            By default all jobs will run.
+        --batch=<job index range> Job index or range of indexes to run.
+                            By default, ":" to run all jobs.
 
         --continue          Try to continue from existing trajectories
                             in the output.
@@ -38,15 +38,51 @@ function parse_cli_args(cli_args, jobs::Vector{String})::Union{CLIOptions, Nothi
 
     out_dir = something(parse_option!(cli_args, "--out"), ".")
 
-    batch_str = something(parse_option!(cli_args, "--batch"), "-1")
-    batch = tryparse(Int, batch_str)
-    batch_range = 1:length(jobs)
-    if isnothing(batch)
-        @error "--batch must be a integer, instead got $(repr(batch_str))"
-        return
+    batch_str = something(parse_option!(cli_args, "--batch"), ":")
+    function batch_error()
+        @error "--batch must be an integer or a range, instead got $(repr(batch_str))"
+        nothing
     end
-    if !(batch == -1 || batch ∈ batch_range)
-        @error "--batch must be -1 or in $(batch_range), instead got $(batch)"
+    function tryparse_batchpart(part)
+        if part == "end"
+            length(jobs)
+        elseif part == "begin"
+            1
+        else
+            tryparse(Int, part)
+        end
+    end
+    # Backwards compat
+    if batch_str == "-1"
+        batch_str = ":"
+    end
+    batch_parts = strip.(split(batch_str, ":"))
+    batchns = tryparse_batchpart.(batch_parts)
+    batch_range = if length(batch_parts) == 1
+        if isnothing(only(batchns))
+            return batch_error()
+        end
+        batchns[1]:length(jobs):length(jobs)
+    elseif length(batch_parts) == 2
+        if all(isempty, batch_parts)
+            # plain :
+            1:1:length(jobs)
+        elseif any(isnothing, batchns)
+            return batch_error()
+        else
+            batchns[1]:1:batchns[2]
+        end
+    elseif length(batch_parts) == 3
+        if any(isnothing, batchns)
+            return batch_error()
+        else
+            batchns[1]:batchns[2]:batchns[3]
+        end
+    else
+        return batch_error()
+    end::StepRange{Int, Int}
+    if !issubset(batch_range, 1:length(jobs)) 
+        @error "--batch must be a subset of $(1:length(jobs)), instead got $(batch_range)"
         return
     end
 
@@ -57,7 +93,7 @@ function parse_cli_args(cli_args, jobs::Vector{String})::Union{CLIOptions, Nothi
 
     return CLIOptions(;
         continue_sim,
-        batch,
+        batch_range,
         out_dir,
     )
 end

--- a/src/run-sim.jl
+++ b/src/run-sim.jl
@@ -72,6 +72,7 @@ function run(cli_args;
     end
     options::CLIOptions = something(maybe_options)
     # TODO run all jobs in parallel
+    @info "Running $(length(options.batch_range)) jobs with indexes $(options.batch_range)"
     for job in jobs[options.batch_range]
         if options.continue_sim
             continue_job(options.out_dir, job;

--- a/src/run-sim.jl
+++ b/src/run-sim.jl
@@ -71,29 +71,8 @@ function run(cli_args;
         return
     end
     options::CLIOptions = something(maybe_options)
-    if options.batch == -1
-        # TODO run all jobs in parallel
-        for job in jobs
-            if options.continue_sim
-                continue_job(options.out_dir, job;
-                    setup,
-                    loop,
-                    save,
-                    load,
-                    done,
-                )
-            else
-                start_job(options.out_dir, job;
-                    setup,
-                    loop,
-                    save,
-                    load,
-                    done,
-                )
-            end
-        end
-    else
-        job = jobs[options.batch]
+    # TODO run all jobs in parallel
+    for job in jobs[options.batch_range]
         if options.continue_sim
             continue_job(options.out_dir, job;
                 setup,

--- a/test/test_arg-parsing.jl
+++ b/test/test_arg-parsing.jl
@@ -8,41 +8,175 @@ using MEDYANSimRunner
             String[], ["job1", "job2"]
         ) == MEDYANSimRunner.CLIOptions(;
             continue_sim=false,
-            batch=-1,
+            batch_range=1:1:2,
             out_dir=".",
         )
     @test MEDYANSimRunner.parse_cli_args(
             String["--continue"], ["job1", "job2"]
         ) == MEDYANSimRunner.CLIOptions(;
             continue_sim=true,
-            batch=-1,
+            batch_range=1:1:2,
             out_dir=".",
         )
     @test MEDYANSimRunner.parse_cli_args(
             String["--out=/home/nathan/sim1"], ["job1", "job2"]
         ) == MEDYANSimRunner.CLIOptions(;
             continue_sim=false,
-            batch=-1,
+            batch_range=1:1:2,
             out_dir="/home/nathan/sim1",
         )
     @test MEDYANSimRunner.parse_cli_args(
             String["--batch=-1"], ["job1", "job2"]
         ) == MEDYANSimRunner.CLIOptions(;
             continue_sim=false,
-            batch=-1,
+            batch_range=1:1:2,
             out_dir=".",
         )
-    @test (@test_logs (:error, "--batch must be -1 or in 1:2, instead got 3") MEDYANSimRunner.parse_cli_args(
-            String["--batch=3"], ["job1", "job2"]
-        )) === nothing
-    @test (@test_logs (:error, "--batch must be a integer, instead got \"dfgdf\"") MEDYANSimRunner.parse_cli_args(
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=3"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=3:4:4,
+            out_dir=".",
+        )
+
+    # Test range parsing with various formats
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=1:3"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:1:3,
+            out_dir=".",
+        )
+    
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=1:2:4"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:2:4,
+            out_dir=".",
+        )
+
+    # Test plain colon (all jobs)
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=:"], ["job1", "job2", "job3"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:1:3,
+            out_dir=".",
+        )
+
+    # Test begin/end keywords
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=begin:end"], ["job1", "job2", "job3"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:1:3,
+            out_dir=".",
+        )
+
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=begin:2:end"], ["job1", "job2", "job3", "job4", "job5"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:2:5,
+            out_dir=".",
+        )
+
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=2:end"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=2:1:4,
+            out_dir=".",
+        )
+
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=begin:3"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:1:3,
+            out_dir=".",
+        )
+
+    # Test edge cases and error conditions
+    @test (@test_logs (:error, "--batch must be an integer or a range, instead got \"dfgdf\"") MEDYANSimRunner.parse_cli_args(
             String["--batch=dfgdf"], ["job1", "job2"]
         )) === nothing
+
+    @test (@test_logs (:error, "--batch must be an integer or a range, instead got \"1:2:3:4\"") MEDYANSimRunner.parse_cli_args(
+            String["--batch=1:2:3:4"], ["job1", "job2", "job3", "job4"]
+        )) === nothing
+
+    @test (@test_logs (:error, "--batch must be an integer or a range, instead got \"abc:def\"") MEDYANSimRunner.parse_cli_args(
+            String["--batch=abc:def"], ["job1", "job2", "job3", "job4"]
+        )) === nothing
+
+    @test (@test_logs (:error, "--batch must be an integer or a range, instead got \"1:abc:3\"") MEDYANSimRunner.parse_cli_args(
+            String["--batch=1:abc:3"], ["job1", "job2", "job3", "job4"]
+        )) === nothing
+
+    @test (@test_logs (:error, "--batch must be an integer or a range, instead got \"\"") MEDYANSimRunner.parse_cli_args(
+            String["--batch="], ["job1", "job2", "job3", "job4"]
+        )) === nothing
+
+    # Test out of bounds batch range
+    @test (@test_logs (:error, r"--batch must be a subset of 1:2, instead got 3:1:5") MEDYANSimRunner.parse_cli_args(
+            String["--batch=3:5"], ["job1", "job2"]
+        )) === nothing
+
+    # Test more edge cases
+    # Single job range
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=2"], ["job1", "job2", "job3"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=2:3:3,
+            out_dir=".",
+        )
+
+    # Empty step in range (should default to 1)
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=2:4"], ["job1", "job2", "job3", "job4", "job5"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=2:1:4,
+            out_dir=".",
+        )
+
+    # Test with mixed begin/end and numbers
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=begin:2"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:1:2,
+            out_dir=".",
+        )
+
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=3:end"], ["job1", "job2", "job3", "job4"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=3:1:4,
+            out_dir=".",
+        )
+
+    # Test step size that is larger than range
+    @test MEDYANSimRunner.parse_cli_args(
+            String["--batch=1:10:3"], ["job1", "job2", "job3"]
+        ) == MEDYANSimRunner.CLIOptions(;
+            continue_sim=false,
+            batch_range=1:10:3,
+            out_dir=".",
+        )
+
+    # Test unused arguments warning
     @test (@test_logs (:warn, "not all ARGS used") MEDYANSimRunner.parse_cli_args(
         String["--bach=dfgdf"], ["job1", "job2"]
         )) == MEDYANSimRunner.CLIOptions(;
             continue_sim=false,
-            batch=-1,
+            batch_range=1:1:2,
             out_dir=".",
         )
+    
 end


### PR DESCRIPTION
This allows running a subset of jobs in a single process.

This is useful to avoid job or process limits on Zaratan.

The tests were generated by Claude